### PR TITLE
Fix path resolution

### DIFF
--- a/lib/PMLTQ/PML2BASE.pm
+++ b/lib/PMLTQ/PML2BASE.pm
@@ -460,7 +460,8 @@ sub _abs2rel {
       return $file;
     }
   }
-  $file = Cwd::abs_path($file);
+  # This shouldn't be needed anymore
+  #$file = Cwd::abs_path($file);
   return File::Spec->abs2rel($file,$base);
 }
 


### PR DESCRIPTION
Resolving paths with symlinks will end up with error.

Since the paths are constructed using `pmltq convert` the extra `Cwd::abs_path` shouldn't be necessary.