### PR TITLE
Add hack to convert interset in treex

### DIFF
--- a/Changes
+++ b/Changes
@@ -7,8 +7,10 @@ Revision history for {{$dist->name}}
  - Fixing path resolution
 
  [DOCUMENTATION]
+ - Fix several POD errors and add POD testing
 
  [ENHANCEMENTS]
+ - Hack conversion of Lingua::Interset::FeatureStructure
 
 1.0.1
  - Released: 2015-12-17 15:09:11 UTC

--- a/lib/PMLTQ/PML2BASE.pm
+++ b/lib/PMLTQ/PML2BASE.pm
@@ -897,6 +897,11 @@ sub traverse_data {
         my $mdump = traverse_data($d,$v);
         $desc->{$n} = data_index($mdump);
       } else {
+        # HACK for Interset structure
+        if (ref $v && UNIVERSAL::DOES::does($value, 'Lingua::Interset::FeatureStructure')) {
+          $v = [ map { $_ . '=' . $v->{$_} } keys $v ] if ref $v eq 'HASH';
+          $v = join ('|', @$v) if ref $v eq 'ARRAY';
+        }
         my ($key,$value) = col_val($d,$table,$n,$v);
         $desc->{$key} = $value;
       }

--- a/lib/PMLTQ/PML2BASE.pm
+++ b/lib/PMLTQ/PML2BASE.pm
@@ -899,7 +899,7 @@ sub traverse_data {
       } else {
         # HACK for Interset structure
         if (ref $v && UNIVERSAL::DOES::does($value, 'Lingua::Interset::FeatureStructure')) {
-          $v = [ map { $_ . '=' . $v->{$_} } keys $v ] if ref $v eq 'HASH';
+          $v = [ map { $_ . '=' . $v->{$_} } keys %$v ] if ref $v eq 'HASH';
           $v = join ('|', @$v) if ref $v eq 'ARRAY';
         }
         my ($key,$value) = col_val($d,$table,$n,$v);


### PR DESCRIPTION
Treex is messing with underlying PML structures which results in errors during conversion. This hack should fix it.